### PR TITLE
Fix Zizmor issues in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: 'Integrate'
 on:
   - push
   - pull_request
+
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: 'CI'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
+          persist-credentials: false
       - name: 'Install the Rust toolchain'
         uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,15 +26,13 @@ jobs:
         with:
           submodules: true
           persist-credentials: false
-      - name: 'Install the Rust toolchain'
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          toolchain: ${{ matrix.toolchain }}
+      - name: 'Setup the Rust toolchain'
+        run: |
+          rustup override set ${{ matrix.toolchain }}
+          rustup --version
+          rustc --version
+          cargo --version
       - name: 'Build the library'
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: build
+        run: cargo build
       - name: 'Run tests for the library'
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
-        with:
-          command: test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,18 @@ jobs:
           - nightly
     steps:
       - name: 'Checkout the repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: true
       - name: 'Install the Rust toolchain'
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: 'Build the library'
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: build
       - name: 'Run tests for the library'
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
         with:
           command: test


### PR DESCRIPTION
We hit Zizmor issues in the RRG repository (google/rrg#256), so I proactively fix it here as well. This includes fixes to:

  * [`unpinned-uses`](https://docs.zizmor.sh/audits/#unpinned-uses)
  * [`archived-uses`](https://docs.zizmor.sh/audits/#archived-uses)
  * [`ref-version-mismatch`](https://docs.zizmor.sh/audits/#ref-version-mismatch)
  * [`artipacked`](https://docs.zizmor.sh/audits/#artipacked)